### PR TITLE
Add evaluation binary that parses tasks from file

### DIFF
--- a/scheduling/CMakeLists.txt
+++ b/scheduling/CMakeLists.txt
@@ -51,16 +51,26 @@ set(SOURCES
     common/helpFunctions.cu
     common/deviceProps.cu
     common/maskElement.cu
+    executive/scheduling.cu
+    executive/runbenchmark.cu
 )
 
-# Define executable
 add_executable(
     benchmark_${SCHEDULER_TYPE}
     ${SOURCES} schedulerTestBenchmark.cu
 )
-
-# Link CUDA and smctrl
 target_link_libraries(benchmark_${SCHEDULER_TYPE}
+    PRIVATE
+        smctrl
+        cuda
+        cudart
+)
+
+add_executable(
+    evaluation
+    ${SOURCES} evaluation.cu
+)
+target_link_libraries(evaluation
     PRIVATE
         smctrl
         cuda

--- a/scheduling/benchmarks/customBenchmarks/firstTest.py
+++ b/scheduling/benchmarks/customBenchmarks/firstTest.py
@@ -1,3 +1,5 @@
+#!/usr/bin/env python3
+
 import pathlib
 from typing import Dict, Any, List
 import sys

--- a/scheduling/evaluation.cu
+++ b/scheduling/evaluation.cu
@@ -1,0 +1,113 @@
+#include <fstream>
+#include <unordered_map>
+
+#include "tasks/task.h"
+
+#include "jobs/busyJob/busyJob.h"
+#include "jobs/jobFactory/jobFactory.h"
+#include "jobs/printJob/printJob.h"
+#include "jobs/vectorAddJob/vectorAddJob.h"
+#include "jobs/matrixMultiplicationJob/matrixMultiplicationJob.h"
+#include "schedulers/schedulerBase/scheduler.h"
+#include "schedulers/JLFPScheduler/JLFP.h"
+#include "schedulers/FCFSScheduler/FCFSScheduler.h"
+#include "schedulers/dumbScheduler/dumbScheduler.h"
+
+#include "executive/scheduling.h"
+#include "executive/runbenchmark.h"
+
+
+// Parses CLI args of the form --key value into a map
+std::unordered_map<std::string, std::string> parseArgs(int argc, char* argv[]) {
+    std::unordered_map<std::string, std::string> args;
+    for (int i = 1; i < argc - 1; ++i) {
+        std::string key = argv[i];
+        if (key.rfind("--", 0) == 0) { // starts with "--"
+            args[key.substr(2)] = argv[++i];
+        }
+    }
+    return args;
+}
+
+std::vector<Task> parseTaskSetFromFile(const std::string& filepath) {
+    std::ifstream file(filepath);
+    std::vector<std::string> tokens;
+    std::string token;
+
+    if (!file) {
+        std::cerr << "Failed to open task file: " << filepath << std::endl;
+        return {};
+    }
+
+    while (file >> token) {
+        tokens.push_back(token);
+    }
+
+    if (tokens.empty()) {
+        std::cerr << "No input in file.\n";
+        return {};
+    }
+
+    const int taskCount = std::stoi(tokens[0]);
+    const size_t expectedTokens = 1 + taskCount * 7;
+
+    if (tokens.size() < expectedTokens) {
+        std::cerr << "Not enough tokens in task file. Expected " << expectedTokens
+                  << ", got " << tokens.size() << std::endl;
+        return {};
+    }
+
+    std::vector<Task> tasks;
+    size_t idx = 1;
+    for (int i = 0; i < taskCount; ++i) {
+        std::string type = tokens[idx++];
+        int offset = std::stoi(tokens[idx++]);
+        int wcet = std::stoi(tokens[idx++]);
+        int deadline = std::stoi(tokens[idx++]);
+        int period = std::stoi(tokens[idx++]);
+        int threadsPerBlock = std::stoi(tokens[idx++]);
+        int blockCount = std::stoi(tokens[idx++]);
+
+        std::unique_ptr<JobFactoryBase> factory;
+
+        if (type == "busy") {
+            factory = JobFactory<BusyJob, int, int>::create(threadsPerBlock, blockCount);
+        } else if (type == "print") {
+            factory = JobFactory<PrintJob, int, int>::create(threadsPerBlock, blockCount);
+        } else {
+            std::cerr << "Unknown job type: " << type << std::endl;
+            return {};
+        }
+
+        tasks.emplace_back(offset, wcet, deadline, period, std::move(factory), i);
+    }
+
+    return tasks;
+}
+
+int main(int argc, char* argv[]) {
+    auto args = parseArgs(argc, argv);
+
+    const std::string schedulerType = args.count("scheduler") ? args["scheduler"] : "JLFP";
+    const std::string taskFilePath = args.count("task-file") ? args["task-file"] : "";
+
+    const int tpcSplitDenom = TPC_SPLIT_DENOM;
+
+    if (taskFilePath.empty()) {
+        std::cerr << "Missing --task-file argument.\n";
+        return 1;
+    }
+
+    auto scheduler = createScheduler(schedulerType, tpcSplitDenom);
+    if (!scheduler) return 1;
+
+    auto tasks = parseTaskSetFromFile(taskFilePath);
+    if (tasks.empty()) {
+        std::cerr << "Malformed taskset file.\n";
+        return 1;
+    }
+
+    runBenchmark(scheduler.get(), tasks, 5);
+
+    return 0;
+}

--- a/scheduling/executive/runbenchmark.cu
+++ b/scheduling/executive/runbenchmark.cu
@@ -1,0 +1,54 @@
+
+#include "../executive/runbenchmark.h"
+
+// Function to run the benchmark
+void runBenchmark(
+    BaseScheduler *scheduler,
+    std::vector<Task>& tasks,
+    int benchmarkDurationSeconds
+) {
+    // Metrics to track
+    int jobsCompleted = 0;
+    int jobsMissedDeadline = 0;
+    float totalExecutionTime = 0.0f;
+    std::vector<float> executionTimes;
+
+    // Start timing
+    auto startTime = std::chrono::high_resolution_clock::now();
+
+    // Run for a fixed amount of time
+    auto endTime = startTime + std::chrono::seconds(benchmarkDurationSeconds);
+
+    while (std::chrono::high_resolution_clock::now() < endTime) {
+        // Process any tasks that are ready to release jobs
+        for (auto &task : tasks) {
+            if (task.isJobReady()) {
+                scheduler->addJob(task.releaseJob());
+            }
+        }
+
+        // Dispatch jobs according to the scheduler
+        scheduler->dispatch();
+    }
+
+    // Collect and print results
+    auto totalTime = std::chrono::duration_cast<std::chrono::milliseconds>(
+            std::chrono::high_resolution_clock::now() - startTime)
+                             .count() /
+                     1000.0;
+
+    // collected values from scheduler.
+    jobsCompleted = scheduler->getJobsCompleted();
+    jobsMissedDeadline = scheduler->getDeadlineMisses();
+
+    float throughput = jobsCompleted / totalTime;
+
+    std::cout << "Benchmark Results:" << std::endl;
+    std::cout << "Scheduler: " << SCHEDULER_TYPE << std::endl;
+    std::cout << "Threads Per Block: " << THREADS_PER_BLOCK << std::endl;
+    std::cout << "Block Count: " << BLOCK_COUNT << std::endl;
+    std::cout << "Execution time: " << totalTime << " seconds" << std::endl;
+    std::cout << "Jobs completed: " << jobsCompleted << std::endl;
+    std::cout << "Jobs missed deadline: " << jobsMissedDeadline << std::endl;
+    std::cout << "Throughput: " << throughput << " jobs/second" << std::endl;
+}

--- a/scheduling/executive/runbenchmark.h
+++ b/scheduling/executive/runbenchmark.h
@@ -1,0 +1,6 @@
+#pragma once
+
+#include "../schedulers/schedulerBase/scheduler.h"
+#include "../tasks/task.h"
+
+void runBenchmark(BaseScheduler *scheduler, std::vector<Task>& tasks, int benchmarkDurationSeconds);

--- a/scheduling/executive/scheduling.cu
+++ b/scheduling/executive/scheduling.cu
@@ -1,0 +1,19 @@
+
+#include "../executive/scheduling.h"
+#include "../schedulers/JLFPScheduler/JLFP.h"
+#include "../schedulers/FCFSScheduler/FCFSScheduler.h"
+#include "../schedulers/dumbScheduler/dumbScheduler.h"
+
+// Function to create a scheduler based on type
+std::unique_ptr<BaseScheduler> createScheduler(const std::string &type, int tpcSplitDenom) {
+    if (type == "JLFP") {
+        return std::make_unique<JLFP>(tpcSplitDenom);
+    } else if (type == "FCFS") {
+        return std::make_unique<FCFSScheduler>();
+    } else if (type == "dumbScheduler") {
+        return std::make_unique<DumbScheduler>();
+    } else {
+        std::cerr << "Unknown scheduler type: " << type << std::endl;
+        return nullptr;
+    }
+}

--- a/scheduling/executive/scheduling.h
+++ b/scheduling/executive/scheduling.h
@@ -1,0 +1,4 @@
+
+#include "../schedulers/schedulerBase/scheduler.h"
+
+std::unique_ptr<BaseScheduler> createScheduler(const std::string &type, int tpcSplitDenom);


### PR DESCRIPTION
Refactor a couple of functions from the `schedulerTestBenchmark.cu` file to make them reusable for other binaries, such that in the `evaluation.cu` file we directly parse the task set from a text file and use the same utility functions.